### PR TITLE
docs: move definition of terms to glossary and update definitions

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -16,9 +16,9 @@ design:
     request access to use for a specific purpose. This request, when approved, 
     will result in a data extract that is sent to the Data Requester.
   instance: |
-    An Instance of Seedcase is one installation of Seedcase products. This could include
-    all software within the Seedcase framework or only some parts of it.
-    An Instance can contain multiple Data Projects and Data Resources.
+    An Instance of the Seedcase infrastructure  can include all software products 
+    within the Seedcase framework or only some parts of it.
+    An Instance can contain one Data Resource, but multiple Data Projects.
   seedcase-framework: |
      The software deliverables which work together to implement core project 
      functionalities as a single conceptual unit. Specifically, this includes 

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,17 +1,5 @@
 design:
-  data-resource: |
-    This is the software component that
-    manages and stores data from a research study or data source. For
-    example, our external partner DD2 (listed below in the Stakeholder
-    section) collects a wide variety of data on a set of participants.
-    The data generated from these participants enrolled with DD2 would
-    form a single "Data Resource".
-  whitebox: |
-    A description of the internal functioning and behaviour of a system.
-    For example, how the internals of the Seedcase framework like the web frontend 
-    part, the programmatic API part, and the data backend environment part interact
-    with each other. "White" implying seen or visible (e.g. daylight).
-  blackbox: |
+  black-box: |
     A description of the external functioning and behaviour of a system that
     doesn't include *how* it works internally. For example, how the API part of
     the Seedcase framework connects and communicates with other Seedcase software 
@@ -20,5 +8,29 @@ design:
   crud: |
     An acronym for Create, Read, Update, and Delete. These four actions are the
     core operations for data storage on computers.
+  data-resource: |
+    The data layer of the framework and its contents. 
+    A data resource will stores data from a research study or data source.
+  data-project: |
+    A subset of data from a Data Resource that researchers or other analysts
+    request access to use for a specific purpose. This request, when approved, 
+    will result in a data extract that is sent to the Data Requester.
   instance: |
-    An Instance of Seedcase is .. <!--TODO Finish text here. -->
+    An Instance of Seedcase is one installation of Seedcase products. This could include
+    all software within the Seedcase framework or only some parts of it.
+    An Instance can contain multiple Data Projects and Data Resources.
+  seedcase-framework: |
+     The software deliverables which work together to implement core project 
+     functionalities as a single conceptual unit. Specifically, this includes 
+     the software deliverables Sprout, Propagate, Flower, and Garden. 
+  seedcase-products: |
+    The software deliverables of the Seedcase project collectively.
+    Also called "Seedcase software" or "Seedcase software products". 
+  seedcase-project: | 
+    The Seedcase Project as a whole, including software, documentation, learning material, 
+    as well as underpinning ideas and philosophy.
+  white-box: |
+    A description of the internal functioning and behaviour of a system.
+    For example, how the internals of the Seedcase framework like the web frontend 
+    part, the programmatic API part, and the data backend environment part interact
+    with each other. "White" implying seen or visible (e.g. daylight).

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,5 +1,5 @@
 design:
-  black-box: |
+  closed-box: |
     A description of the external functioning and behaviour of a system that
     doesn't include *how* it works internally. For example, how the API part of
     the Seedcase framework connects and communicates with other Seedcase software 
@@ -20,17 +20,17 @@ design:
     within the Seedcase framework or only some parts of it.
     An Instance can contain one Data Resource, but multiple Data Projects.
   seedcase-framework: |
-     The software deliverables which work together to implement core project 
+     The software products that work together to implement the core project 
      functionalities as a single conceptual unit. Specifically, this includes 
-     the software deliverables Sprout, Propagate, Flower, and Garden. 
+     the software products Sprout, Propagate, Flower, and Garden. 
   seedcase-products: |
-    The software deliverables of the Seedcase project collectively.
+    The software products of the Seedcase project collectively.
     Also called "Seedcase software" or "Seedcase software products". 
   seedcase-project: | 
     The Seedcase Project as a whole, including software, documentation, learning material, 
     as well as underpinning ideas and philosophy.
-  white-box: |
+  open-box: |
     A description of the internal functioning and behaviour of a system.
     For example, how the internals of the Seedcase framework like the web frontend 
     part, the programmatic API part, and the data backend environment part interact
-    with each other. "White" implying seen or visible (e.g. daylight).
+    with each other. Open implying transparent or visible.

--- a/_variables.yml
+++ b/_variables.yml
@@ -9,8 +9,7 @@ design:
     An acronym for Create, Read, Update, and Delete. These four actions are the
     core operations for data storage on computers.
   data-resource: |
-    The data layer of the framework and its contents. 
-    A data resource will stores data from a research study or data source.
+    Is the research data and metadata, and any management needed, of a specific research study. 
   data-project: |
     A subset of data from a Data Resource that researchers or other analysts
     request access to use for a specific purpose. This request, when approved, 

--- a/software/glossary.qmd
+++ b/software/glossary.qmd
@@ -7,7 +7,7 @@ order: 100
 
 This page includes a glossary of the terms we use to describe different parts of the software architecture in the Seedcase Project.
 
-## Seedcase specific terms
+## Seedcase-specific terms
 
 | Term |Definition |
 | --- | --- |

--- a/software/glossary.qmd
+++ b/software/glossary.qmd
@@ -1,0 +1,28 @@
+---
+title: "Glossary"
+order: 100
+---
+
+{{< include /includes/_wip.qmd >}}
+
+This page includes a glossary of the terms we use to describe different parts of the software architecture in the Seedcase Project.
+
+## Seedcase specific terms
+
+| Term |Definition |
+| --- | --- |
+| Data Resource  | {{< var design.data-resource >}} |
+| Data Project  | {{< var design.data-project >}} |
+| Instance  | {{< var design.instance >}} |
+| Seedcase Framework  | {{< var design.seedcase-framework >}} |
+| Seedcase Products  | {{< var design.seedcase-products >}} |
+| Seedcase Project  | {{< var design.seedcase-project >}} |
+
+## General terms
+
+| Term |Definition |
+| --- | --- |
+| Black box | {{< var design.black-box >}} |
+| CRUD | {{< var design.crud >}} |
+| White box  | {{< var design.white-box >}} |
+

--- a/software/glossary.qmd
+++ b/software/glossary.qmd
@@ -22,7 +22,7 @@ This page includes a glossary of the terms we use to describe different parts of
 
 | Term |Definition |
 | --- | --- |
-| Black box | {{< var design.black-box >}} |
+| Closed box | {{< var design.closed-box >}} |
 | CRUD | {{< var design.crud >}} |
-| White box  | {{< var design.white-box >}} |
+| Open box  | {{< var design.open-box >}} |
 

--- a/software/introduction.qmd
+++ b/software/introduction.qmd
@@ -29,17 +29,6 @@ site](https://community.seedcase-project.org) page. While these aims are
 not related to the software itself, it does impact architectural and
 design decisions we make.
 
-## Definition of terms
-
--   **Seedcase Product**: This is a piece of Seedcase software that is
-    installed on a computer or server.
--   **Data Resource**: {{< var design.data-resource >}}
--   **Data Project**: A data project, also called a data extract, would
-    be a subset of data from a Data Resource that researchers or other
-    analysts would request access to use for a specific purpose. This
-    request, when approved, would result in a data extract that is sent
-    to the user.
-
 ## Requirements Overview
 
 Primary **goals** of Seedcase software are:


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds a glossary by moving the "Definition of terms" section from the introduction and updating/adding definitions of relevant terms. 
- These changes are done so we 1) are clear on what is meant when we use specific terms and 2) can link to these definitions throughout the documentation.

## Related Issues

<!-- List issues the PR closes -->

Closes #28 

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

- Please check the definitions and suggest changes to them if they aren't correct 
- Are we missing some definitions? 
- Does it make sense to include two sections in the glossary like I have done here? One for Seedcase specific terms and one for more general ones? 

## Checklist

For general documentation:

- [X] Spell-check
- [X] Did the page(s) preview correctly on your machine without breaking
- [ ] New category words (keywords) (if any) added to the code snippet file