### PR TITLE
docs: :memo: expand on docstrings style guide

### DIFF
--- a/style/code.qmd
+++ b/style/code.qmd
@@ -24,11 +24,11 @@ description: "Guidelines on how to write and style code"
 ## docstrings
 
 -   Write docstrings for every function, class, and method.
--   Use the `"""` triple quotes for docstrings.
--   Use sentence case for describing things and end with a full stop.  
-    So use:  `path: The path to the file.`  
-    Rather than:  `path: the path to the file`
--   Use a tab when creating a new line for the description.
+    -   Use the `"""` triple quotes for docstrings.
+    -   Use sentence case for describing things and end with a full stop.  
+        So use:  `path: The path to the file.`  
+        Rather than:  `path: the path to the file`
+    -   Use a tab when creating a new line for the description.
 -   Write simple one-line docstrings for: very small functions (\<5
     lines), functions with \<2 arguments, and functions with simple
     and clear input and output

--- a/style/code.qmd
+++ b/style/code.qmd
@@ -21,14 +21,16 @@ description: "Guidelines on how to write and style code"
     function should chain together the smaller functions to achieve the
     larger action.
 
-## docstrings
+### docstrings
 
 -   Write docstrings for every function, class, and method.
     -   Use the `"""` triple quotes for docstrings.
     -   Use sentence case for describing things and end with a full stop.  
-        So use:  `path: The path to the file.`  
-        Rather than:  `path: the path to the file`
+        So use `path: The path to the file.` 
+        rather than `path: the path to the file`.
     -   Use a tab when creating a new line for the description.
+-   Use the [Google style](https://google.github.io/styleguide/pyguide.html#s3.8.1-comments-in-doc-strings) for writing the docstrings. When adding docstrings in Seedcase projects
+    this will automatically be added by the autoDocstring VS Code extension.
 -   Write simple one-line docstrings for: very small functions (\<5
     lines), functions with \<2 arguments, and functions with simple
     and clear input and output

--- a/style/code.qmd
+++ b/style/code.qmd
@@ -15,15 +15,23 @@ description: "Guidelines on how to write and style code"
     -   Avoid "side effects" (actions that are not part of the output)
 -   Prefer using functional programming over object-oriented
     programming.
--   Write docstrings for every function, class, and method.
-    -   Write simple one-line docstrings for: very small functions (\<5
-        lines), functions with \<2 arguments, and functions with simple
-        and clear input and output
-    -   Write longer and more detailed docstrings for: larger functions,
-        functions with several arguments, user-facing functions, and
-        those with more complex or non-standard inputs or outputs.
 -   Write type hints for inputs and returns.
 -   *Most* functions and methods should prefer to have a single, simple
     action. More complex actions (especially user-facing ones) done by a
     function should chain together the smaller functions to achieve the
     larger action.
+
+## docstrings
+
+-   Write docstrings for every function, class, and method.
+-   Use the `"""` triple quotes for docstrings.
+-   Use sentence case for describing things and end with a full stop.  
+    So use:  `path: The path to the file.`  
+    Rather than:  `path: the path to the file`
+-   Use a tab when creating a new line for the description.
+-   Write simple one-line docstrings for: very small functions (\<5
+    lines), functions with \<2 arguments, and functions with simple
+    and clear input and output
+-   Write longer and more detailed docstrings for: larger functions,
+    functions with several arguments, user-facing functions, and
+    those with more complex or non-standard inputs or outputs.

--- a/style/naming.qmd
+++ b/style/naming.qmd
@@ -88,7 +88,7 @@ Some general guidelines when naming things in Python:
 -   Prefer action verbs only: `ClassName.action()`.
 -   Avoid using object names, unless it makes the action clearer.
 
-#### Classes:
+#### Classes
 
 -   Use `PascalCase`.
 -   Use objects as the class name: `Object`.


### PR DESCRIPTION
## Description

These changes are done for clarity in using docstrings, because this should be kept with the rest of the documentation.

Closes #136, closes #139 

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. 

## Checklist

- [x] Ran spell-check
- [x] Formatted Markdown
- [x] Rendered website locally
