### PR TITLE
fix: 🩹 remove development from style sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -38,10 +38,7 @@ website:
         - data/index.qmd
     - id: style
       contents:
-        - style/index.qmd
-        - style/code.qmd
-        - style/naming.qmd
-        - style/tests.qmd
+        - auto: style/
     - id: accessibility
       contents:
         - accessibility/index.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -40,7 +40,6 @@ website:
       contents:
         - style/index.qmd
         - style/code.qmd
-        - style/development.qmd
         - style/naming.qmd
         - style/tests.qmd
     - id: accessibility


### PR DESCRIPTION
## Description

I created this PR to remove `development` from the `style` sidebar (first commit). But I then realised that it might be nicer to just use `auto` to include all files in the `styles/` directory instead of having to list them individually (second commit).

The result is the same for now*: `development` is removed from the `style` sidebar, 

*as long as we want to include all files in the `styles/` directory.

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [ ] Ran spell-check
- [ ] Formatted Markdown
- [X] Rendered website locally