### PR TITLE
chore: 🧑‍💻 include platform-docs team in qmd as well

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # All members on Developers team get added to review PRs
 * @seedcase-project/admin @seedcase-project/platform-docs
-*.qmd @seedcase-project/everyone
+*.qmd @seedcase-project/everyone @seedcase-project/platform-docs


### PR DESCRIPTION
# Description

I realized that this team also needs to be included with `*.qmd` as well.

This PR needs no review.
